### PR TITLE
[emitter-framework] Use Alloy for InterfaceMember

### DIFF
--- a/packages/emitter-framework/src/typescript/components/interface-declaration.tsx
+++ b/packages/emitter-framework/src/typescript/components/interface-declaration.tsx
@@ -35,26 +35,17 @@ export function InterfaceDeclaration(props: InterfaceDeclarationProps) {
 
   const extendsType = props.extends ?? getExtendsType(props.type);
 
-  const members = props.type ? [membersFromType(props.type)] : [];
-
-  const children = [...members];
-
-  if (Array.isArray(props.children)) {
-    children.push(...props.children);
-  } else if (props.children) {
-    children.push(props.children);
-  }
-
   return (
     <ts.InterfaceDeclaration
       default={props.default}
       export={props.export}
-      children={children}
       kind={props.kind}
       name={name}
       refkey={refkey}
       extends={extendsType}
-    ></ts.InterfaceDeclaration>
+    >
+      {interfaceMembers(props)}
+    </ts.InterfaceDeclaration>
   );
 }
 
@@ -69,13 +60,10 @@ export interface InterfaceExpressionProps extends ts.InterfaceExpressionProps {
 }
 
 export function InterfaceExpression({ type, children }: InterfaceExpressionProps) {
-  const members = type ? membersFromType(type) : [];
-
   return (
     <>
       {"{"}
-      {members}
-      {children}
+      {interfaceMembers({ type, children })}
       {"}"}
     </>
   );
@@ -123,7 +111,7 @@ function getExtendsType(type: Model | Interface): Children | undefined {
   );
 }
 
-function membersFromType(type: Model | Interface): Children {
+function interfaceMembers({ type, children }: TypedInterfaceDeclarationProps) {
   let typeMembers: RekeyableMap<string, ModelProperty | Operation> | undefined;
   if ($.model.is(type)) {
     typeMembers = $.model.getProperties(type);
@@ -143,10 +131,13 @@ function membersFromType(type: Model | Interface): Children {
   }
 
   return (
-    <ay.For each={Array.from(typeMembers.entries())} line>
-      {([_, prop]) => {
-        return <InterfaceMember type={prop} />;
-      }}
-    </ay.For>
+    <>
+      <ay.For each={Array.from(typeMembers.entries())} line ender=";">
+        {([_, prop]) => {
+          return <InterfaceMember type={prop} />;
+        }}
+      </ay.For>
+      {children}
+    </>
   );
 }

--- a/packages/emitter-framework/src/typescript/components/interface-declaration.tsx
+++ b/packages/emitter-framework/src/typescript/components/interface-declaration.tsx
@@ -49,13 +49,12 @@ export function InterfaceDeclaration(props: InterfaceDeclarationProps) {
     <ts.InterfaceDeclaration
       default={props.default}
       export={props.export}
+      children={children}
       kind={props.kind}
       name={name}
       refkey={refkey}
       extends={extendsType}
-    >
-      {children}
-    </ts.InterfaceDeclaration>
+    ></ts.InterfaceDeclaration>
   );
 }
 

--- a/packages/emitter-framework/src/typescript/components/interface-member.tsx
+++ b/packages/emitter-framework/src/typescript/components/interface-member.tsx
@@ -51,6 +51,7 @@ export function InterfaceMember(props: InterfaceMemberProps) {
           </>
         }
         refkey={props.refkey ?? ay.refkey(props.type)}
+        readonly={Boolean(props.type.decorators?.find((d) => d.decorator.name === "@readonly"))}
       />
     );
   }

--- a/packages/emitter-framework/src/typescript/components/interface-member.tsx
+++ b/packages/emitter-framework/src/typescript/components/interface-member.tsx
@@ -1,4 +1,5 @@
-import { useTSNamePolicy } from "@alloy-js/typescript";
+import * as ay from "@alloy-js/core";
+import * as ts from "@alloy-js/typescript";
 import { isNeverType, ModelProperty, Operation } from "@typespec/compiler";
 import { $ } from "@typespec/compiler/experimental/typekit";
 import { getHttpPart } from "@typespec/http";
@@ -8,39 +9,49 @@ import { TypeExpression } from "./type-expression.js";
 export interface InterfaceMemberProps {
   type: ModelProperty | Operation;
   optional?: boolean;
+  refkey?: ay.Refkey;
 }
 
-export function InterfaceMember({ type, optional }: InterfaceMemberProps) {
-  const namer = useTSNamePolicy();
-  const name = namer.getName(type.name, "object-member-getter");
+export function InterfaceMember(props: InterfaceMemberProps) {
+  const namer = ts.useTSNamePolicy();
+  const name = namer.getName(props.type.name, "object-member-getter");
 
-  if ($.modelProperty.is(type)) {
-    const optionality = optional === true || type.optional === true ? "?" : "";
-
-    if (isNeverType(type.type)) {
+  if ($.modelProperty.is(props.type)) {
+    if (isNeverType(props.type.type)) {
       return null;
     }
 
-    let unpackedType = type.type;
-    const part = getHttpPart($.program, type.type);
+    let unpackedType = props.type.type;
+    const part = getHttpPart($.program, props.type.type);
     if (part) {
       unpackedType = part.type;
     }
 
     return (
-      <>
-        "{name}"{optionality}: <TypeExpression type={unpackedType} />;
-      </>
+      <ts.InterfaceMember
+        name={name}
+        optional={props.optional === true || props.type.optional === true}
+        type={<TypeExpression type={unpackedType} />}
+        refkey={ay.refkey(props.type)}
+        readonly={Boolean(props.type.decorators?.find((d) => d.decorator.name === "@readonly"))}
+      />
     );
   }
 
-  if ($.operation.is(type)) {
-    const returnType = <TypeExpression type={type.returnType} />;
-    const params = <FunctionDeclaration.Parameters type={type.parameters} />;
+  if ($.operation.is(props.type)) {
+    const returnType = <TypeExpression type={props.type.returnType} />;
+    const params = <FunctionDeclaration.Parameters type={props.type.parameters} />;
+
     return (
-      <>
-        {name}({params}): {returnType};
-      </>
+      <ts.InterfaceMember
+        name={name}
+        type={
+          <>
+            ({params}): {returnType}
+          </>
+        }
+        refkey={props.refkey ?? ay.refkey(props.type)}
+      />
     );
   }
 }

--- a/packages/emitter-framework/test/typescript/components/member-expression.test.tsx
+++ b/packages/emitter-framework/test/typescript/components/member-expression.test.tsx
@@ -36,7 +36,7 @@ describe("Typescript Enum Member Expression", () => {
         three = 3
       }
       interface Bar {
-        "one": Foo.one;
+        one: Foo.one;
       }
     `);
   });
@@ -70,7 +70,7 @@ describe("Typescript Enum Member Expression", () => {
         three = "three"
       }
       interface Bar {
-        "one": Foo.one;
+        one: Foo.one;
       }
     `);
   });
@@ -102,7 +102,7 @@ describe("Typescript Union Member Expression", () => {
     expect(output).toBe(d`
       type Foo = 1 | 2 | 3;
       interface Bar {
-        "one": 1;
+        one: 1;
       }
     `);
   });
@@ -132,7 +132,7 @@ describe("Typescript Union Member Expression", () => {
     expect(output).toBe(d`
       type Foo = "one" | "two" | "three";
       interface Bar {
-        "one": "one";
+        one: "one";
       }
     `);
   });


### PR DESCRIPTION
## What

- Removes bespoke implementation of InterfaceMember in favor of Alloy
- Updates test expectation

## Why

Using Alloy here provides a few benefits: proper quoting of member names,
providing refkey, etc.
